### PR TITLE
Disable geometry edition button instead of hide in read-only layers

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -181,6 +181,7 @@ Development
 * Merged fix subdomain error not loading tiles (CartoDB.js#1607)
 * Fixed way to listen Deep-insights.js map or widgets changes (#11894)
 * Using latest cartodb.js and deep-insights.js to tackle map zooming problem (support#605)
+* Disable geometry edition button instead of hide in read-only layers (#11543)
 
 4.0.x (2016-12-05)
 ------------------

--- a/lib/assets/core/javascripts/cartodb3/editor/layers/change-view-buttons.tpl
+++ b/lib/assets/core/javascripts/cartodb3/editor/layers/change-view-buttons.tpl
@@ -32,115 +32,113 @@
   </li>
 </ul>
 
-<% if (!isReadOnly) { %>
-  <div class="EditOverlay js-editOverlay is-hidden"><p class="EditOverlay-inner CDB-Text CDB-Size-medium u-whiteTextColor js-editOverlay-text"></p></div>
+<div class="EditOverlay js-editOverlay is-hidden"><p class="EditOverlay-inner CDB-Text CDB-Size-medium u-whiteTextColor js-editOverlay-text"></p></div>
 
-  <ul class="u-flex u-alignRight Editor-contextSwitcher Editor-contextSwitcher--geom js-mapTableView js-newGeometryView
-  <% if (context === 'table') { %>in-table<% } %>
-  <% if (isThereOtherWidgets && context === 'map') { %>is-moved<% } %>
-  <% if (isThereTimeSeries && context === 'map') { %>
-    has-timeSeries
-    <% if (isThereAnimatedTimeSeries) { %>
-      has-timeSeries--animated
-    <% } %>
+<ul class="u-flex u-alignRight Editor-contextSwitcher Editor-contextSwitcher--geom js-mapTableView js-newGeometryView
+<% if (context === 'table') { %>in-table<% } %>
+<% if (isThereOtherWidgets && context === 'map') { %>is-moved<% } %>
+<% if (isThereTimeSeries && context === 'map') { %>
+  has-timeSeries
+  <% if (isThereAnimatedTimeSeries) { %>
+    has-timeSeries--animated
   <% } %>
-  ">
-    <% if (queryGeometryModel === 'point' || !queryGeometryModel) { %>
-      <li class="Editor-contextSwitcherItem js-newGeometryItem <% if (!isVisible) { %>is-disabled<% } %>">
-        <div class="Editor-contextSwitcherButton js-newGeometry" data-feature-type='point'>
-          <svg width="12" height="12" viewBox="0 0 12 12" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
-            <defs>
-              <path d="M0 2h3v1H0V2zm0-2h3v1H0V0zm2 1h1v1H2V1zM0 1h1v1H0V1z" id="a"/>
-              <path d="M0 2h3v1H0V2zm0-2h3v1H0V0zm2 1h1v1H2V1zM0 1h1v1H0V1z" id="c"/>
-              <path d="M0 2h3v1H0V2zm0-2h3v1H0V0zm2 1h1v1H2V1zM0 1h1v1H0V1z" id="e"/>
-            </defs>
-            <g fill="none" fill-rule="evenodd">
-              <path fill="#FFF" d="M4 3h3v1H4v3H3V4H0V3h3V0h1"/>
-              <g transform="rotate(180 2.5 6)">
-                <mask id="b" fill="#fff">
-                  <use xlink:href="#a"/>
-                </mask>
-                <path d="M0 2h3v1H0V2zm0-2h3v1H0V0zm2 1h1v1H2V1zM0 1h1v1H0V1z" mask="url(#b)" stroke="#FFF" stroke-width="2"/>
-              </g>
-              <g transform="rotate(180 6 6)">
-                <mask id="d" fill="#fff">
-                  <use xlink:href="#c"/>
-                </mask>
-                <path d="M0 2h3v1H0V2zm0-2h3v1H0V0zm2 1h1v1H2V1zM0 1h1v1H0V1z" mask="url(#d)" stroke="#FFF" stroke-width="2"/>
-              </g>
-              <g transform="rotate(180 6 2.5)">
-                <mask id="f" fill="#fff">
-                  <use xlink:href="#e"/>
-                </mask>
-                <path d="M0 2h3v1H0V2zm0-2h3v1H0V0zm2 1h1v1H2V1zM0 1h1v1H0V1z" mask="url(#f)" stroke="#FFF" stroke-width="2"/>
-              </g>
-            </g>
-          </svg>
-        </div>
-      </li>
-    <% } %>
-    <% if (queryGeometryModel === 'line' || !queryGeometryModel) { %>
-      <li class="Editor-contextSwitcherItem js-newGeometryItem <% if (!isVisible) { %>is-disabled<% } %>">
-        <div class="Editor-contextSwitcherButton js-newGeometry" data-feature-type='line'>
-          <svg width="14" height="14" viewBox="0 0 14 14" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
-            <defs>
-              <path d="M0 2h3v1H0V2zm0-2h3v1H0V0zm2 1h1v1H2V1zM0 1h1v1H0V1z" id="a"/>
-              <path d="M0 2h3v1H0V2zm0-2h3v1H0V0zm2 1h1v1H2V1zM0 1h1v1H0V1z" id="c"/>
-            </defs>
-            <g fill="none" fill-rule="evenodd">
-              <path fill="#FFF" d="M11.5 5l-.707-.707-6.354 6.853.705.708"/>
-              <g transform="translate(11 2)">
-                <mask id="b" fill="#fff">
-                  <use xlink:href="#a"/>
-                </mask>
-                <path d="M0 2h3v1H0V2zm0-2h3v1H0V0zm2 1h1v1H2V1zM0 1h1v1H0V1z" mask="url(#b)" stroke="#FFF" stroke-width="2"/>
-              </g>
-              <g transform="translate(2 11)">
-                <mask id="d" fill="#fff">
-                  <use xlink:href="#c"/>
-                </mask>
-                <path d="M0 2h3v1H0V2zm0-2h3v1H0V0zm2 1h1v1H2V1zM0 1h1v1H0V1z" mask="url(#d)" stroke="#FFF" stroke-width="2"/>
-              </g>
-              <path fill="#FFF" d="M3 4H0V3h3V0h1v3h3v1H4v3H3"/>
-            </g>
-          </svg>
-        </div>
-      </li>
-    <% } %>
-    <% if (queryGeometryModel === 'polygon' || !queryGeometryModel) { %>
-      <li class="Editor-contextSwitcherItem js-newGeometryItem <% if (!isVisible) { %>is-disabled<% } %>">
-        <div class="Editor-contextSwitcherButton js-newGeometry" data-feature-type='polygon'>
-          <svg width="14" height="14" viewBox="0 0 14 14" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
-            <defs>
-              <path d="M0 2h3v1H0V2zm0-2h3v1H0V0zm2 1h1v1H2V1zM0 1h1v1H0V1z" id="a"/>
-              <path d="M0 2h3v1H0V2zm0-2h3v1H0V0zm2 1h1v1H2V1zM0 1h1v1H0V1z" id="c"/>
-              <path d="M0 2h3v1H0V2zm0-2h3v1H0V0zm2 1h1v1H2V1zM0 1h1v1H0V1z" id="e"/>
-            </defs>
-            <g fill="none" fill-rule="evenodd">
-              <path d="M13 11.5V5h-1v7h1m-.5-7.5l-.707-.707-7.647 7.353-.353.354.707.707.354-.353M4 3h3v1H4v3H3V4H0V3h3V0h1" fill="#FFF"/>
-              <path fill="#FFF" d="M4.5 13H12v-1H4v1"/>
-              <g transform="rotate(180 7 7)">
-                <mask id="b" fill="#fff">
-                  <use xlink:href="#a"/>
-                </mask>
-                <path d="M0 2h3v1H0V2zm0-2h3v1H0V0zm2 1h1v1H2V1zM0 1h1v1H0V1z" stroke="#FFF" stroke-width="2" mask="url(#b)"/>
-              </g>
-              <g transform="rotate(180 7 2.5)">
-                <mask id="d" fill="#fff">
-                  <use xlink:href="#c"/>
-                </mask>
-                <path d="M0 2h3v1H0V2zm0-2h3v1H0V0zm2 1h1v1H2V1zM0 1h1v1H0V1z" stroke="#FFF" stroke-width="2" mask="url(#d)"/>
-              </g>
-              <g transform="rotate(180 2.5 7)">
-                <mask id="f" fill="#fff">
-                  <use xlink:href="#e"/>
-                </mask>
-                <path d="M0 2h3v1H0V2zm0-2h3v1H0V0zm2 1h1v1H2V1zM0 1h1v1H0V1z" stroke="#FFF" stroke-width="2" mask="url(#f)"/>
-              </g>
-            </g>
-          </svg>
-        </div>
-      </li>
-    <% } %>
-  </ul>
 <% } %>
+">
+  <% if (queryGeometryModel === 'point' || !queryGeometryModel) { %>
+    <li class="Editor-contextSwitcherItem js-newGeometryItem <% if (!isVisible || isReadOnly) { %>is-disabled<% } %>">
+      <div class="Editor-contextSwitcherButton js-newGeometry" data-feature-type='point'>
+        <svg width="12" height="12" viewBox="0 0 12 12" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+          <defs>
+            <path d="M0 2h3v1H0V2zm0-2h3v1H0V0zm2 1h1v1H2V1zM0 1h1v1H0V1z" id="a"/>
+            <path d="M0 2h3v1H0V2zm0-2h3v1H0V0zm2 1h1v1H2V1zM0 1h1v1H0V1z" id="c"/>
+            <path d="M0 2h3v1H0V2zm0-2h3v1H0V0zm2 1h1v1H2V1zM0 1h1v1H0V1z" id="e"/>
+          </defs>
+          <g fill="none" fill-rule="evenodd">
+            <path fill="#FFF" d="M4 3h3v1H4v3H3V4H0V3h3V0h1"/>
+            <g transform="rotate(180 2.5 6)">
+              <mask id="b" fill="#fff">
+                <use xlink:href="#a"/>
+              </mask>
+              <path d="M0 2h3v1H0V2zm0-2h3v1H0V0zm2 1h1v1H2V1zM0 1h1v1H0V1z" mask="url(#b)" stroke="#FFF" stroke-width="2"/>
+            </g>
+            <g transform="rotate(180 6 6)">
+              <mask id="d" fill="#fff">
+                <use xlink:href="#c"/>
+              </mask>
+              <path d="M0 2h3v1H0V2zm0-2h3v1H0V0zm2 1h1v1H2V1zM0 1h1v1H0V1z" mask="url(#d)" stroke="#FFF" stroke-width="2"/>
+            </g>
+            <g transform="rotate(180 6 2.5)">
+              <mask id="f" fill="#fff">
+                <use xlink:href="#e"/>
+              </mask>
+              <path d="M0 2h3v1H0V2zm0-2h3v1H0V0zm2 1h1v1H2V1zM0 1h1v1H0V1z" mask="url(#f)" stroke="#FFF" stroke-width="2"/>
+            </g>
+          </g>
+        </svg>
+      </div>
+    </li>
+  <% } %>
+  <% if (queryGeometryModel === 'line' || !queryGeometryModel) { %>
+    <li class="Editor-contextSwitcherItem js-newGeometryItem <% if (!isVisible || isReadOnly) { %>is-disabled<% } %>">
+      <div class="Editor-contextSwitcherButton js-newGeometry" data-feature-type='line'>
+        <svg width="14" height="14" viewBox="0 0 14 14" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+          <defs>
+            <path d="M0 2h3v1H0V2zm0-2h3v1H0V0zm2 1h1v1H2V1zM0 1h1v1H0V1z" id="a"/>
+            <path d="M0 2h3v1H0V2zm0-2h3v1H0V0zm2 1h1v1H2V1zM0 1h1v1H0V1z" id="c"/>
+          </defs>
+          <g fill="none" fill-rule="evenodd">
+            <path fill="#FFF" d="M11.5 5l-.707-.707-6.354 6.853.705.708"/>
+            <g transform="translate(11 2)">
+              <mask id="b" fill="#fff">
+                <use xlink:href="#a"/>
+              </mask>
+              <path d="M0 2h3v1H0V2zm0-2h3v1H0V0zm2 1h1v1H2V1zM0 1h1v1H0V1z" mask="url(#b)" stroke="#FFF" stroke-width="2"/>
+            </g>
+            <g transform="translate(2 11)">
+              <mask id="d" fill="#fff">
+                <use xlink:href="#c"/>
+              </mask>
+              <path d="M0 2h3v1H0V2zm0-2h3v1H0V0zm2 1h1v1H2V1zM0 1h1v1H0V1z" mask="url(#d)" stroke="#FFF" stroke-width="2"/>
+            </g>
+            <path fill="#FFF" d="M3 4H0V3h3V0h1v3h3v1H4v3H3"/>
+          </g>
+        </svg>
+      </div>
+    </li>
+  <% } %>
+  <% if (queryGeometryModel === 'polygon' || !queryGeometryModel) { %>
+    <li class="Editor-contextSwitcherItem js-newGeometryItem <% if (!isVisible || isReadOnly) { %>is-disabled<% } %>">
+      <div class="Editor-contextSwitcherButton js-newGeometry" data-feature-type='polygon'>
+        <svg width="14" height="14" viewBox="0 0 14 14" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+          <defs>
+            <path d="M0 2h3v1H0V2zm0-2h3v1H0V0zm2 1h1v1H2V1zM0 1h1v1H0V1z" id="a"/>
+            <path d="M0 2h3v1H0V2zm0-2h3v1H0V0zm2 1h1v1H2V1zM0 1h1v1H0V1z" id="c"/>
+            <path d="M0 2h3v1H0V2zm0-2h3v1H0V0zm2 1h1v1H2V1zM0 1h1v1H0V1z" id="e"/>
+          </defs>
+          <g fill="none" fill-rule="evenodd">
+            <path d="M13 11.5V5h-1v7h1m-.5-7.5l-.707-.707-7.647 7.353-.353.354.707.707.354-.353M4 3h3v1H4v3H3V4H0V3h3V0h1" fill="#FFF"/>
+            <path fill="#FFF" d="M4.5 13H12v-1H4v1"/>
+            <g transform="rotate(180 7 7)">
+              <mask id="b" fill="#fff">
+                <use xlink:href="#a"/>
+              </mask>
+              <path d="M0 2h3v1H0V2zm0-2h3v1H0V0zm2 1h1v1H2V1zM0 1h1v1H0V1z" stroke="#FFF" stroke-width="2" mask="url(#b)"/>
+            </g>
+            <g transform="rotate(180 7 2.5)">
+              <mask id="d" fill="#fff">
+                <use xlink:href="#c"/>
+              </mask>
+              <path d="M0 2h3v1H0V2zm0-2h3v1H0V0zm2 1h1v1H2V1zM0 1h1v1H0V1z" stroke="#FFF" stroke-width="2" mask="url(#d)"/>
+            </g>
+            <g transform="rotate(180 2.5 7)">
+              <mask id="f" fill="#fff">
+                <use xlink:href="#e"/>
+              </mask>
+              <path d="M0 2h3v1H0V2zm0-2h3v1H0V0zm2 1h1v1H2V1zM0 1h1v1H0V1z" stroke="#FFF" stroke-width="2" mask="url(#f)"/>
+            </g>
+          </g>
+        </svg>
+      </div>
+    </li>
+  <% } %>
+</ul>

--- a/lib/assets/core/test/spec/cartodb3/editor/layers/layer-content-view.spec.js
+++ b/lib/assets/core/test/spec/cartodb3/editor/layers/layer-content-view.spec.js
@@ -147,8 +147,10 @@ describe('editor/layers/layer-content-view/lcv', function () {
 
   describe('._renderContextButtons', function () {
     var analysisDefNodeModel;
+    var layerDefinitionModel;
     beforeEach(function () {
       analysisDefNodeModel = this.view._getAnalysisDefinitionNodeModel();
+      layerDefinitionModel = this.view._layerDefinitionModel;
       spyOn(analysisDefNodeModel, 'isReadOnly');
       this.view._renderContextButtons();
     });
@@ -158,14 +160,28 @@ describe('editor/layers/layer-content-view/lcv', function () {
       expect($(dashboardCanvasEl).find('.Editor-contextSwitcherButton.js-showMap').length).toBe(1);
     });
 
-    it('should not display edit geometry buttons when node is read only', function () {
+    it('should enable edit geometry buttons when node is visible', function () {
       analysisDefNodeModel.isReadOnly.and.returnValue(false);
-      expect($(dashboardCanvasEl).find('.Editor-contextSwitcherItem.js-newGeometryItem').length).toBe(3);
+      layerDefinitionModel.set('visible', true);
+      expect($(dashboardCanvasEl).find('.Editor-contextSwitcherItem.js-newGeometryItem.is-disabled').length).toBe(0);
     });
 
-    it('should not display edit geometry buttons when node is read only', function () {
+    it('should disable edit geometry buttons when node is hidden', function () {
+      analysisDefNodeModel.isReadOnly.and.returnValue(false);
+      layerDefinitionModel.set('visible', false);
+      expect($(dashboardCanvasEl).find('.Editor-contextSwitcherItem.js-newGeometryItem.is-disabled').length).toBe(3);
+    });
+
+    it('should disable edit geometry buttons when node is read only', function () {
       analysisDefNodeModel.isReadOnly.and.returnValue(true);
-      expect($(dashboardCanvasEl).find('.Editor-contextSwitcherItem.js-newGeometryItem').length).toBe(3);
+      layerDefinitionModel.set('visible', true);
+      expect($(dashboardCanvasEl).find('.Editor-contextSwitcherItem.js-newGeometryItem.is-disabled').length).toBe(3);
+    });
+
+    it('should enable edit geometry buttons when node is not read only', function () {
+      analysisDefNodeModel.isReadOnly.and.returnValue(false);
+      layerDefinitionModel.set('visible', true);
+      expect($(dashboardCanvasEl).find('.Editor-contextSwitcherItem.js-newGeometryItem.is-disabled').length).toBe(0);
     });
   });
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "4.6.60",
+  "version": "4.6.61",
   "description": "CARTO UI frontend",
   "repository": {
     "type": "git",


### PR DESCRIPTION
When a layer is read only we were hiding the geometry edition buttons, now we're showing them but with a disable state.

Before:
![screen shot 2017-04-05 at 22 31 11](https://cloud.githubusercontent.com/assets/905225/24787338/1a4e56f2-1b68-11e7-827f-0addb626281f.png)

After:
![screen shot 2017-04-05 at 22 33 36](https://cloud.githubusercontent.com/assets/905225/24787340/203796e6-1b68-11e7-963d-2737e7a99ca1.png)
